### PR TITLE
Pin imintengine to @v0.1.0 (agentic_workflow rollout W1.3)

### DIFF
--- a/tutorials/environment.yml
+++ b/tutorials/environment.yml
@@ -8,6 +8,8 @@ channels:
   - conda-forge
 
 dependencies:
+  - folium
+  - contextily
   - python=3.10
   - gdal=3.6.3
   - rasterio
@@ -38,6 +40,12 @@ dependencies:
   - descartes # plot polygons with holes
   - numpy>=1.9
   - pip:
+    # Pinned to v0.1.0 per agentic_workflow rollout plan W1.3 (2026-04-24).
+    # NOTE: the DigitalEarthSweden org transfer is pending (see ImintEngine's
+    # docs/imintengine-transfer-plan.md). Until then this URL 404s — to
+    # actually run this notebook, temporarily replace with
+    # TobiasEdman/imintengine.git@v0.1.0. Switch back after org transfer.
+    - git+https://github.com/DigitalEarthSweden/imintengine.git@v0.1.0#egg=imintengine
     - openeo
     - rioxarray  # for rasterio xarray extensions, optional but useful for geospatial data
     - nc-time-axis  # for plotting cftime.datetime objects with matplotlib


### PR DESCRIPTION
## Summary

Pins `git+...imintengine.git` in `tutorials/environment.yml` from `@main` to `@v0.1.0` so downstream tutorial users don't silently track unreleased HEAD changes.

Part of [agentic_workflow rollout plan W1.3](https://github.com/TobiasEdman/agentic_workflow/blob/main/docs/rollout_plan.md) — removing `@main` references across the TobiasEdman/DigitalEarthSweden repo graph.

## Known caveat

This file references `DigitalEarthSweden/imintengine`, which is the planned org after transfer (see `docs/imintengine-transfer-plan.md` in ImintEngine). The URL currently returns 404. Until the transfer completes, users running this notebook need to temporarily substitute `TobiasEdman/imintengine.git@v0.1.0`.

An inline comment in `environment.yml` explains this so the next reader doesn't have to rediscover it.

## ImintEngine v0.1.0

Tag cut 2026-04-24 at `TobiasEdman/imintengine` commit `fc72078`. First stable tag baselining the current 23-class unified schema + dual-head architecture + imint.config.secrets hardening. Downstream repos (leo-constellation, space-data-lab, this one) pin to this tag to prevent silent breakage.

## Test plan

- [ ] CI pipeline passes (tutorials still build)
- [ ] After the DES org transfer of imintengine, drop the workaround comment