### PR TITLE
CI: add merge-gateway workflow

### DIFF
--- a/.github/workflows/merge-gateway.yaml
+++ b/.github/workflows/merge-gateway.yaml
@@ -1,0 +1,25 @@
+name: merge-gateway
+
+on:
+  pull_request:
+
+permissions: {}
+
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  merge-gateway:
+    permissions:
+      checks: read # Required for reading the status of other workflows.
+    # August 2026: cannot use github.repository_owner for uses: for security
+    #              reasons.
+    uses: DigitalEarthSweden/.github/.github/workflows/merge-gateway.yaml@main
+    with:
+      # Timeout of longest workflow (main.yaml).
+      timeout: 85
+    secrets:
+      repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is required for enabling
auto-merge in renovate.